### PR TITLE
Fix: Assignment DatHuis

### DIFF
--- a/technical-assignments/Assignment-DatHuis/.babelrc
+++ b/technical-assignments/Assignment-DatHuis/.babelrc
@@ -1,0 +1,25 @@
+{
+  "presets": [
+    "@babel/react",
+    [
+      "@babel/env",
+      {
+        "targets": {
+          "browsers": [">0.25%", "not op_mini all"]
+        }
+      }
+    ]
+  ],
+  "plugins": [
+    "@babel/plugin-proposal-class-properties",
+    [
+      "babel-plugin-root-import",
+      {
+        "rootPathSuffix": "./src",
+        "rootPathPrefix": "~"
+      }
+    ],
+    "babel-plugin-styled-components",
+    "react-hot-loader/babel"
+  ]
+}

--- a/technical-assignments/Assignment-DatHuis/.gitignore
+++ b/technical-assignments/Assignment-DatHuis/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.dist


### PR DESCRIPTION
The app fails without `.babelrc` file in assignment root.
Git tracks changes in `node_modules` folder without `.gitignore`.

This commit adds both files from [Rob's repo](https://github.com/robvk/dh-frontend-assignment) .